### PR TITLE
feat: enfoce providing the radix to parseInt

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -43,5 +43,8 @@ module.exports = {
 
         // prevents direct comparison with NaN
         'use-isnan': 'error',
+
+        // require use of the second argument for parseInt()
+        radix: 'error',
     },
 };


### PR DESCRIPTION
### Motivation:
`parseInt` will not default to base 10, [see](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Parameters)

This rule enforces user to explicitly provide the radix when using `parseInt`

### Argument:

If we are **never** intending to use this style guide for ES5-, we can ignore this rule, [Quoting rule description:](https://eslint.org/docs/rules/radix)


> When using the parseInt() function it is common to omit the second argument, the radix, and let the function try to determine from the first argument what type of number it is. By default, parseInt() will autodetect decimal and hexadecimal (via 0x prefix). Prior to ECMAScript 5, parseInt() also autodetected octal literals, which caused problems because many developers assumed a leading 0 would be ignored.